### PR TITLE
Using superLayer in samples for general compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ myFirstView = new Layer
 	name: "initialView"
 	width: 750, height: 1334
 	image: "images/screen01.png"
-	parent: vnc
+	superLayer: vnc
 
 mySecondView = new Layer
 	width: 750, height: 1334
 	image: "images/screen02.png"
-	parent: vnc
+	superLayer: vnc
 ```
 To add them to the view controller, just make sure the it's their parent. You can see I've also set the `name` property of `myFirstView` to `initialView`. This tells the view controller that I want to start with this view appearing first.
 


### PR DESCRIPTION
The first basic sample doesn't work with the use of `parent` property instead of `superLayer` (tested on two computers, with the latest FrameJS version). This is probably a FramerJS bug, but in the meantime, I've adapted the sample accordingly (which by the way matches the sample you included in the .coffee file)
